### PR TITLE
Use a CI specific profile for nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Do not cancel the test run on the first failure.
+fail-fast = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest,cargo-llvm-cov
-      - run: cargo llvm-cov nextest --workspace run
+      - run: cargo llvm-cov nextest --workspace run --profile=ci
 
   # Check formatting with rustfmt
   formatting:


### PR DESCRIPTION
- Prevent "fail fast" in CI (we want to run all tests, not just all
  until the first failure)
- Print the output of failures immediately, and again at the end of the
  test run
