### PR TITLE
Fix test runner (all tests were skipped)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest,cargo-llvm-cov
-      - run: cargo llvm-cov nextest --workspace run --profile=ci
+      - run: cargo llvm-cov nextest --workspace --profile=ci
 
   # Check formatting with rustfmt
   formatting:


### PR DESCRIPTION
All tests were being skipped prior to this change. The reason is that
`llvm-cov nextest` doesn't have a subcommand named `run`. So when I
changed from `cargo nextest run` to `cargo llvm-cov nextest run` the
`run` part was being treated like a test name filter!!

Ooops...
