### PR TITLE
Attempt simpler build system for artifacts.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Upload current_bin
+        uses: actions/upload-artifact@v4
+        with:
+          name: context-version-exec-current_bin-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/current_bin
+
+      - name: Upload prior_bin
+        uses: actions/upload-artifact@v4
+        with:
+          name: context-version-exec-prior_bin-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/prior_bin


### PR DESCRIPTION
This version of building artifacts relies on the fact that we can
specify a `--target` to `cargo build` to compile for an alternate
platform (as opposed to creating a docker build and whatnot for each).
