### PR TITLE
Refactor caching for building artifacts.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          # setup-rust-toolchain automatically uses Swatinem/rust-cache with some
+          # default settings, but we need to tweak those settings to get a rust-cache
+          # for each platform instead
+          cache: false
           target: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: "${{ matrix.job.os }}-${{ matrix.job.target }}"
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
Prior to this, we were using the default caching setup from
`actions-rust-lang/setup-rust-toolchain@v1` which uses
`Swatinem/rust-cache@v2` (with mostly all default values).

This turns caching off from `setup-rust-toolchain` and directly adds the
`Swatinem/rust-cache` action so that we can configure more options.
Specifically, we want to configure `key` so that we get separate cache
keys for each `os` and `target`. This _should_ allow us to shave off a
bit more time from the build workflow.
