### PR TITLE
Upload a single artifact for each target platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,14 +40,8 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Upload current_bin
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: context-version-exec-current_bin-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/current_bin
-
-      - name: Upload prior_bin
-        uses: actions/upload-artifact@v4
-        with:
-          name: context-version-exec-prior_bin-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/prior_bin
+          name: ${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/


### PR DESCRIPTION
actions/upload-artifact can upload the entire release directory (instead
of just individual bins uploaded via multiple calls).
